### PR TITLE
Items & Chests are saved in the cookies

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
                 <legend>Item Tracker</legend>
                 <button type="button" onclick="EditMode()">Edit Mode</button>
                 <button type="button" onclick="ResetLayout()">Reset Layout</button>
+                <button type="button" onclick="ResetTracker()">Reset Tracker</button>
                 <br>
                 Size<input type="range" name='itemdivsize' value='100' max='200' min='1' onchange="setZoom('itemdiv', this)">
                 <span id='itemdivsize'>100%</span><br>

--- a/script/items.js
+++ b/script/items.js
@@ -70,7 +70,7 @@ var defaultItemGrid = [
 ]
 
 
-var items = {
+var baseItems = {
     Bow:0,
     Hookshot:0,
     Hammer:false,
@@ -155,3 +155,5 @@ var itemsMax = {
     Wallet:2,
     Skulltula:5,
 };
+
+var items = Object.assign(baseItems);

--- a/script/main.js
+++ b/script/main.js
@@ -42,7 +42,8 @@ var cookieDefault = {
     mPos:0,
     glogic:'Open',
     prize:1,
-    items:defaultItemGrid
+    layout:defaultItemGrid,
+    items:items
 }
 
 var cookielock = false;
@@ -59,7 +60,9 @@ function loadCookie() {
         }
     });
 
-    initGridRow(JSON.parse(JSON.stringify(cookieobj.items)));
+    initGridRow(JSON.parse(JSON.stringify(cookieobj.layout)));
+    items = JSON.parse(JSON.stringify(cookieobj.items));
+    updateGridItemAll();
 
     document.getElementsByName('showmap')[0].checked = !!cookieobj.map;
     document.getElementsByName('showmap')[0].onchange();
@@ -103,7 +106,8 @@ function saveCookie() {
             cookieobj.glogic = rbutton.value;
     }
 
-    cookieobj.items = JSON.parse(JSON.stringify(itemLayout));
+    cookieobj.layout = JSON.parse(JSON.stringify(itemLayout));
+    cookieobj.items = JSON.parse(JSON.stringify(items));
 
     setCookie(cookieobj);
 
@@ -575,6 +579,7 @@ function gridItemClick(row, col, corner) {
 
     updateMap()
     updateGridItem(row,col);
+    saveCookie();
 }
 
 function updateMap() {

--- a/script/main.js
+++ b/script/main.js
@@ -34,7 +34,6 @@ function getCookie() {
     return {};
 }
 
-var cookiekeys = ['map', 'iZoom', 'mZoom', 'mOrien', 'mPos', 'glogic', 'prize', 'items'];
 var cookieDefault = {
     map:1,
     iZoom:100,
@@ -54,7 +53,7 @@ function loadCookie() {
 
     cookieobj = getCookie();
 
-    cookiekeys.forEach(function (key) {
+    Object.keys(cookieDefault).forEach(function (key) {
         if (cookieobj[key] === undefined) {
             cookieobj[key] = cookieDefault[key];
         }

--- a/script/main.js
+++ b/script/main.js
@@ -358,6 +358,17 @@ function ResetLayout() {
 }
 
 
+function ResetTracker() {
+    chests.forEach(chest => delete chest.isOpened);
+    dungeons.forEach(dungeon => Object.values(dungeon.chestlist).forEach(chest => delete chest.isOpened));
+    items = Object.assign(baseItems);
+
+    updateGridItemAll();
+    updateMap();
+    saveCookie();
+}
+
+
 function createItemTracker(sender) {
     var r;
     for (r = 0; r < 8; r++) {

--- a/script/main.js
+++ b/script/main.js
@@ -41,8 +41,8 @@ var cookieDefault = {
     mPos:0,
     glogic:'Open',
     prize:1,
-    layout:defaultItemGrid,
-    items:items,
+    items:defaultItemGrid,
+    obtainedItems:items,
     chests:serializeChests(),
     dungeonChests:serializeDungeonChests()
 }
@@ -61,8 +61,8 @@ function loadCookie() {
         }
     });
 
-    initGridRow(JSON.parse(JSON.stringify(cookieobj.layout)));
-    items = JSON.parse(JSON.stringify(cookieobj.items));
+    initGridRow(JSON.parse(JSON.stringify(cookieobj.items)));
+    items = JSON.parse(JSON.stringify(cookieobj.obtainedItems));
     deserializeChests(JSON.parse(JSON.stringify(cookieobj.chests)));
     deserializeDungeonChests(JSON.parse(JSON.stringify(cookieobj.dungeonChests)));
 
@@ -110,8 +110,8 @@ function saveCookie() {
             cookieobj.glogic = rbutton.value;
     }
 
-    cookieobj.layout = JSON.parse(JSON.stringify(itemLayout));
-    cookieobj.items = JSON.parse(JSON.stringify(items));
+    cookieobj.items = JSON.parse(JSON.stringify(itemLayout));
+    cookieobj.obtainedItems = JSON.parse(JSON.stringify(items));
     cookieobj.chests = JSON.parse(JSON.stringify(serializeChests()));
     cookieobj.dungeonChests = JSON.parse(JSON.stringify(serializeDungeonChests()));
 

--- a/script/main.js
+++ b/script/main.js
@@ -125,7 +125,7 @@ function serializeChests(){
 }
 
 function serializeDungeonChests(){
-    return dungeons.map(dungeon => Object.keys(dungeon.chestlist).map(chestName => dungeon.chestlist[chestName].isOpened || false));
+    return dungeons.map(dungeon => Object.values(dungeon.chestlist).map(chest => chest.isOpened || false));
 }
 
 function deserializeChests(serializedChests){


### PR DESCRIPTION
For players that do not play a randomizer in one session (like me), saving the tracked items & chests is essential.

I stored the items, chests & dungeon chests in the cookies by default, so if the user comes back another day, his progress is saved.

To reset the tracker, I added a "Reset Tracker" command in the settings.