### PR TITLE
Add Forest Temple strength requirements to logic

### DIFF
--- a/script/chests.js
+++ b/script/chests.js
@@ -461,26 +461,26 @@ var dungeons = [
             'Outside Hookshot Chest': { isAvailable: function () {
                 return (items.SariasSong || items.MinuetofForest) && items.Hookshot; }, },
             'Falling Room Chest': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && (items.Bow || (items.Dins && items.Magic)); }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Glove) && (items.Bow || (items.Dins && items.Magic)); }, },
             'Block Push Chest': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow; }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow && items.Glove; }, },
             'Boss Key Chest': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow; }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow && items.Glove; }, },
             'Floormaster Chest': { isAvailable: function () {
-                return (items.SariasSong || items.MinuetofForest) && items.Hookshot; }, },
+                return (items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Glove; }, },
             'Bow Chest': { isAvailable: function () {
-                return (items.SariasSong || items.MinuetofForest) && items.Hookshot; }, },
+                return (items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Glove; }, },
             'Red Poe Chest': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow; }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow && items.Glove; }, },
             'Blue Poe Chest': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow; }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot) && items.Bow && items.Glove; }, },
             'Near Boss Chest': { isAvailable: function () {
-                return (items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow; }, },
+                return (items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow && items.Glove; }, },
             'Phantom Ganon': { isAvailable: function () {
-                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow); }, },
+                return ((items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow && items.Glove); }, },
         },
         isBeatable: function() {
-            if ((items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow) {
+            if ((items.SariasSong || items.MinuetofForest) && items.Hookshot && items.Bow && items.Glove) {
                 if (this.canGetChest() == 'available') {
                     return 'available';
                 }


### PR DESCRIPTION
Honor Goron Bracelet requirement to get past block puzzles in Forest Temple.

As pointed out in #8 . @dpeekstok Please confirm that this resolves the issue. You said the last 8 chest should require strength upgrades, but I thought the falling ceiling chest also should require it, and that is the 9th from the last chest in the tracker. I'm too used to doing the Forest Temple in the intended order (it messes me up otherwise), so I don't know how easily the falling ceiling room can be accessed without the bracelet.