### PR TITLE
Add location for Saria on the bridge

### DIFF
--- a/script/chests.js
+++ b/script/chests.js
@@ -1108,5 +1108,13 @@ var chests = [
             return "unavailable";
         },
     },
+    {
+        name: "Saria on the Bridge",
+        x: "74.5%",
+        y: "57.5%",
+        isAvailable: function() {
+            return "available";
+        },
+    },
 ]
 


### PR DESCRIPTION
Most relevant if Ocarinas are shuffled, but still good to keep track of in any case.

Looking over the cookie de/serialization code, it doesn't appear that adding a new location to the end of the global chests list should cause any issues for existing runs.