### PR TITLE
Zora River Grotto Fix

### DIFF
--- a/script/chests.js
+++ b/script/chests.js
@@ -1154,10 +1154,7 @@ var chests = [
         x: "75.5%",
         y: "34.5%",
         isAvailable: function() {
-            if (items.Scale || hasBoom() || items.HoverBoots) {
-                return "available";
-            }
-            return "unavailable";
+            return "available";
         },
     },
     {


### PR DESCRIPTION
Zora River Grotto is not blocked by anything. Can be easily accessible as adult without any requirements.

Maybe this should be renamed Zora River Open Grotto because it's Open?