### PR TITLE
Update Spirit Trial Second Chest with lens logic

### DIFF
--- a/script/chests.js
+++ b/script/chests.js
@@ -560,7 +560,7 @@ var dungeons = [
             'Spirit Trial First Chest': { isAvailable: function () {
                 return isBridgeOpen() && items.Hookshot; }, },
             'Spirit Trial Second Chest': { isAvailable: function () {
-                return isBridgeOpen() && items.Hookshot && items.Magic && items.Lens && hasBoom(); }, },
+                return isBridgeOpen() && items.Hookshot && lens('Semi') && hasBoom(); }, },
             'Light Trial First Left Chest': { isAvailable: function () {
                 return isBridgeOpen() && items.Glove >= 3; }, },
             'Light Trial Second Left Chest': { isAvailable: function () {


### PR DESCRIPTION
I think lens logic was probably added in later, but if we're not requiring lens for stuff like Shadow & Well, it shouldn't be required for Spirit Trial